### PR TITLE
[AE-1672] Update test case, remove hadoop snapp and lzo JARs since they are included by SPARK_DIST_CLASSPATH

### DIFF
--- a/test_spark/test_pyspark_shell.sh
+++ b/test_spark/test_pyspark_shell.sh
@@ -58,12 +58,7 @@ hdfs dfs -put "$spark_test_dir/src/main/resources/normal_sample.txt" spark/test/
 
 echo "ok - testing spark REPL shell with various algorithm"
 mysql_jars=$(find /opt/mysql-connector/ -type f -name "mysql-*.jar")
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-# The guava JAR here does not match the Spark's pom.xml which is looking for version 14.0.1
-# Hive comes with Guava 11.0.2
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra="$spark_opts_extra --jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
+spark_opts_extra=""
 spark_files=$(find $hive_home/lib/ -type f -name "datanucleus*.jar" | tr -s '\n' ',')
 spark_files="$spark_files$mysql_jars,/etc/spark/hive-site.xml"
 

--- a/test_spark/test_pyspark_sparksql.sh
+++ b/test_spark/test_pyspark_sparksql.sh
@@ -69,10 +69,7 @@ if [ ! -f "$spark_test_dir/${app_name}-${app_ver}.jar" ] ; then
 fi
 
 mysql_jars=$(find /opt/mysql-connector/ -type f -name "mysql-*.jar")
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra=" --jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
+spark_opts_extra=""
 spark_files=$(find $hive_home/lib/ -type f -name "datanucleus*.jar" | tr -s '\n' ',')
 spark_files="$spark_files$mysql_jars,${spark_conf}/hive-site.xml"
 
@@ -81,7 +78,7 @@ spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.con
 # pyspark only supports yarn-client mode now
 # queue_name="--queue interactive"
 queue_name=""
-./bin/spark-submit --verbose --master yarn --deploy-mode client --driver-class-path $hadoop_lzo_jar:$hadoop_snappy_jar $queue_name $spark_opts_extra $queue_name --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ --files $spark_files --py-files $spark_home/test_spark/src/main/python/pyspark_hql.py $spark_home/test_spark/src/main/python/pyspark_hql.py
+./bin/spark-submit --verbose --master yarn --deploy-mode client $queue_name $spark_opts_extra $queue_name --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ --files $spark_files --py-files $spark_home/test_spark/src/main/python/pyspark_hql.py $spark_home/test_spark/src/main/python/pyspark_hql.py
 
 if [ $? -ne "0" ] ; then
   >&2 echo "fail - testing shell for Python SparkSQL on HiveQL/HiveContext failed!!"

--- a/test_spark/test_spark_hql.kerberos.sh
+++ b/test_spark/test_spark_hql.kerberos.sh
@@ -84,11 +84,8 @@ for i in `find $hive_home/lib/ -type f -name "datanucleus*.jar"`
 do
   spark_opts_extra="$spark_opts_extra --jars $i"
 done
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
 datanucleus_files=$(find $HIVE_HOME/lib/ -type f -name "datanucleus*.jar" | tr -s '\n' ',')
-spark_opts_extra="/etc/spark/hive-site.xml,${datanucleus_files}$mysql_jars,$hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
+spark_opts_extra="/etc/spark/hive-site.xml,${datanucleus_files}$mysql_jars"
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 

--- a/test_spark/test_spark_hql.sh
+++ b/test_spark/test_spark_hql.sh
@@ -84,11 +84,8 @@ for i in `find $hive_home/lib/ -type f -name "datanucleus*.jar"`
 do
   spark_opts_extra="$spark_opts_extra --jars $i"
 done
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
 datanucleus_files=$(find $HIVE_HOME/lib/ -type f -name "datanucleus*.jar" | tr -s '\n' ',')
-spark_opts_extra="/etc/spark/hive-site.xml,${datanucleus_files}$mysql_jars,$hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
+spark_opts_extra="/etc/spark/hive-site.xml,${datanucleus_files}$mysql_jars"
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 

--- a/test_spark/test_spark_shell.sh
+++ b/test_spark/test_spark_shell.sh
@@ -64,12 +64,7 @@ hdfs dfs -mkdir -p spark/test/naive_bayes
 hdfs dfs -put ${spark_home}/mllib/data/sample_naive_bayes_data.txt spark/test/naive_bayes/
 
 echo "ok - testing spark REPL shell with various algorithm"
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-# The guava JAR here does not match the Spark's pom.xml which is looking for version 14.0.1
-# Hive comes with Guava 11.0.2
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra="$spark_opts_extra --jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
+spark_opts_extra=""
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 

--- a/test_spark/test_spark_shell_graphx.sh
+++ b/test_spark/test_spark_shell_graphx.sh
@@ -52,12 +52,9 @@ hdfs dfs -put ${spark_home}/graphx/data/followers.txt spark/test/graphx/follower
 hdfs dfs -put ${spark_home}/graphx/data/users.txt spark/test/graphx/followers/
 
 echo "ok - testing spark REPL shell with various algorithm"
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
 # The guava JAR here does not match the Spark's pom.xml which is looking for version 14.0.1
 # Hive comes with Guava 11.0.2
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra="$spark_opts_extra --jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
+spark_opts_extra=""
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 

--- a/test_spark/test_spark_shell_mllib_classification.sh
+++ b/test_spark/test_spark_shell_mllib_classification.sh
@@ -57,12 +57,7 @@ hdfs dfs -put $spark_home/mllib/data/sample_libsvm_data.txt spark/test/logistic_
 mkdir -p /tmp/spark_pmml_test/
 
 echo "ok - testing spark REPL shell with various algorithm"
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-# The guava JAR here does not match the Spark's pom.xml which is looking for version 14.0.1
-# Hive comes with Guava 11.0.2
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra="$spark_opts_extra --jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
+spark_opts_extra=""
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 

--- a/test_spark/test_spark_shell_mllib_clustering.sh
+++ b/test_spark/test_spark_shell_mllib_clustering.sh
@@ -59,12 +59,7 @@ hdfs dfs -put $spark_home/mllib/data/kmeans/kmeans_data.txt spark/test/kmean/
 mkdir -p /tmp/spark_pmml_test/
 
 echo "ok - testing spark REPL shell with various algorithm"
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-# The guava JAR here does not match the Spark's pom.xml which is looking for version 14.0.1
-# Hive comes with Guava 11.0.2
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra="$spark_opts_extra --jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
+spark_opts_extra=""
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 

--- a/test_spark/test_spark_shell_mllib_regression.sh
+++ b/test_spark/test_spark_shell_mllib_regression.sh
@@ -52,12 +52,7 @@ hdfs dfs -put $spark_home/mllib/data/ridge-data/lpsa.data spark/test/linear_regr
 mkdir -p /tmp/spark_pmml_test/
 
 echo "ok - testing spark REPL shell with various algorithm"
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-# The guava JAR here does not match the Spark's pom.xml which is looking for version 14.0.1
-# Hive comes with Guava 11.0.2
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra="$spark_opts_extra --jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
+spark_opts_extra=""
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 

--- a/test_spark/test_spark_shell_mllib_tree.sh
+++ b/test_spark/test_spark_shell_mllib_tree.sh
@@ -53,12 +53,7 @@ hdfs dfs -put $spark_home/mllib/data/sample_tree_data.csv spark/test/decision_tr
 mkdir -p /tmp/spark_pmml_test/
 
 echo "ok - testing spark REPL shell with various algorithm"
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-# The guava JAR here does not match the Spark's pom.xml which is looking for version 14.0.1
-# Hive comes with Guava 11.0.2
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra="$spark_opts_extra --jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
+spark_opts_extra=""
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 


### PR DESCRIPTION
Included by default, all hadoop jars are now defined in `spark-env.sh` and `SPARK_DIST_CLASSPATH=$hadoop classpath)`