### PR TITLE
HT-483: Fix all test case to work with Hadoop and Hive JAR provided by spark-env.sh and spark-defaults.conf

### DIFF
--- a/test_spark/deploy_hive_jar.sh
+++ b/test_spark/deploy_hive_jar.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# This script is NOT thread-safe
+# Multiple invocation will result in corrupted zip file
+# Last run wins
+
+source /etc/alti-spark-1.5.2/spark-env.sh
+
+mypid=$$
+tmp_hive_fname_zip=$(basename $(readlink -f $HIVE_HOME))-lib.zip
+tmp_hive_lib_zip_tmp=/tmp/$USER-$tmp_hive_fname_zip-$mypid
+tmp_hive_lib_zip=/tmp/$USER-$tmp_hive_fname_zip
+tmp_hive_lib_zip_md5_tmp=/tmp/$USER-$mypid-$tmp_hive_fname_zip.md5
+tmp_hive_lib_zip_md5=/tmp/$USER-$tmp_hive_fname_zip.md5
+hive_lib_dir=$(readlink -f $HIVE_HOME)/lib
+gen_hive_lib_zip=true
+
+if [ -f $tmp_hive_lib_zip_md5 ] ; then
+  md5sum -c $tmp_hive_lib_zip_md5
+  ret=$?
+  if [ $ret -eq "0" ] ; then
+    echo "ok - no need to re-generate the same $tmp_hive_lib_zip, continuing"
+    gen_hive_lib_zip=false
+  else
+    2>&1 echo "warn - $tmp_hive_lib_zip seems to be corrupted or modified, re-generating a new one"
+    gen_hive_lib_zip=true
+  fi
+fi
+
+if  [ "x$gen_hive_lib_zip" = "xtrue" ] ; then
+  echo "ok - generating first time hive libs $tmp_hive_lib_zip_tmp for pre-deployment"
+  rm -f "$tmp_hive_lib_zip_tmp"
+  pushd $hive_lib_dir
+  zip --quiet -r $tmp_hive_lib_zip_tmp *
+  unzip -qt $tmp_hive_lib_zip_tmp
+  ret=$?
+  popd
+  if [ $ret -eq "0" ] ; then
+    # mv shall be atomic, last write wins
+    mv $tmp_hive_lib_zip_tmp $tmp_hive_lib_zip
+    md5sum $tmp_hive_lib_zip > $tmp_hive_lib_zip_md5_tmp
+    mv $tmp_hive_lib_zip_md5_tmp $tmp_hive_lib_zip_md5
+    echo "ok - generating $tmp_hive_lib_zip and md5sum $tmp_hive_lib_zip_md5 completed successfully"
+  else
+    2>&1 echo "fatal - cannot generate $tmp_hive_lib_zip_tmp from hive libs, zip corrupted"
+    2>&1 echo "fatal - please check disk space/capacity or system resource"
+    rm -f $tmp_hive_lib_zip_tmp
+    exit -9
+  fi
+fi
+
+# Upload the HDFS regardless
+hdfs dfs -mkdir /user/$USER/apps
+hdfs dfs -put $tmp_hive_lib_zip /user/$USER/apps/$tmp_hive_fname_zip

--- a/test_spark/init_spark.sh
+++ b/test_spark/init_spark.sh
@@ -1,15 +1,29 @@
-#!/bin/bash -x
+#!/bin/bash
+
+# This script will honor what the user provides if they want to override the
+# critical env variables SPARK_HOME and SPARK_CONF_DIR, and SPARK_SCALA_VERSION
+# for their own Spark build. If they did specify any of these env variable,
+# our test case will honor them and run it with user's configuration.
+# To perform a sanity check, make sure you use the default test user alti-test-01
+# and apply all default values. If the test case complets, that usually means user's
+# has misconfigure something on their side and indicates an user error.
 
 # We want to honor SPARK_CONF_DIR if someone override this with their
-# own config. Our test case shall pass as well.
-spark_conf_dir_tmp=$SPARK_CONF_DIR
-if [ "x${spark_conf_dir_tmp}" = "x" ] ; then
-  spark_conf_dir_tmp=/etc/spark
-fi
-echo "ok - applying Spark conf $spark_conf_dir_tmp"
+# own config. Other wise, Spark looks for the runtime conf directory which will be under 
+# /opt/spark/conf. Our test case shall pass as well with default configuration provided
+# under /etc/alti-spark-x.x.x
 
+if [ -f "/etc/alti-spark-1.5.2/spark-env.sh" ] ; then
+  source /etc/alti-spark-1.5.2/spark-env.sh
+else
+  >&2 echo "fail - Spark 1.5.2 installation is broken, missing files or directory in /etc/alti-spark-1.5.2"
+  exit -1
+fi
+
+spark_conf_dir_tmp=${SPARK_CONF_DIR:-"/etc/alti-spark-$SPARK_VERSION"}
+echo "ok - applying default or customized Spark conf directory $spark_conf_dir_tmp"
 # Load other env variables defined in the SPARK_CONF_DIR such as SPARK_VERSION, etc.
-# This file must exist for all Spark installation
+# This file must exist for all Spark installation. Applying user customization config if applicable.
 if [ -f "$spark_conf_dir_tmp/spark-env.sh" ] ; then
   source $spark_conf_dir_tmp/spark-env.sh
 else
@@ -17,38 +31,24 @@ else
   exit -1
 fi
 
-spark_version=$SPARK_VERSION
-kerberos_enable=false
-spark_home_tmp=$SPARK_HOME
-
 # Sanity check on SPARK_VERSION
-if [ "x${spark_version}" = "x" ] ; then
+if [ "x${SPARK_VERSION}" = "x" ] ; then
   >&2 echo "fail - cannot detect SPARK_VERSION from $spark_conf_dir_tmp/spark-env.sh"
   >&2 echo "fail - you need to define SPARK_VERSOIN in $spark_conf_dir_tmp/spark-env.sh or SPARK_VERSION env variable"
   exit -1
 fi
 
-# Sanity check on SPARK_HOME
-if [ "x${spark_home_tmp}" = "x" ] ; then
-  spark_home_tmp=/opt/spark
-  if [[ ! -L "$spark_home_tmp" && ! -d "$spark_home_tmp" ]] ; then
-    >&2 echo "fail - $spark_home_tmp does not exist, can't continue, exiting! check spark installation."
-    exit -1
-  fi
-  echo "ok - applying default location $spark_home_tmp"
-fi
-
 # Check Spark RPM installation
-spark_installed=$(rpm -qa | grep alti-spark | grep $spark_version | grep -v test | grep -v example | wc -l)
+spark_installed=$(rpm -qa | grep alti-spark | grep $SPARK_VERSION | grep -v -e example -e shuffle -e kinesis -e sparkts -e devel | wc -l)
 if [ "x${spark_installed}" = "x0" ] ; then
-  >&2 echo "fail - spark for $spark_version not detected or installed, can't continue, exiting"
+  >&2 echo "fail - spark for $SPARK_VERSION not detected or installed, can't continue, exiting"
   >&2 echo "fail - you should install spark via RPM, if you install them from binary distros, you will need to tweak these test case"
   exit -2
 elif [ "x${spark_installed}" = "x1" ] ; then
-  echo "ok - detect one version of spark $spark_version installed that aligns with these test case"
-  echo "ok - $(rpm -q $(rpm -qa | grep alti-spark | grep $spark_version)) installed"
+  echo "ok - detect one version of spark $SPARK_VERSION installed that aligns with these test case"
+  echo "ok - $(rpm -q $(rpm -qa | grep alti-spark | grep $SPARK_VERSION)) installed"
 else
-  echo "warn - detected more than 1 spark $spark_version installed, be aware that test case may refer to different directories"
+  echo "warn - detected more than 1 spark $SPARK_VERSION installed, be aware that test case may refer to different directories"
 fi
 
 # Create HDFS folders for Spark Event logs
@@ -62,5 +62,5 @@ if [ ! -f $spark_conf_tmp ] ; then
 fi
 
 # Prepare Spark user event log HDFS directory for every new users running Spark for the first time
-event_log_dir=$(grep 'spark.history.fs.logDirectory' $spark_conf_tmp | tr -s ' ' '\t' | cut -f2)
+event_log_dir=$(grep 'spark.eventLog.dir' $spark_conf_tmp | tr -s ' ' '\t' | cut -f2)
 hdfs dfs -mkdir $event_log_dir/$USER

--- a/test_spark/launch_example_pyspark_shell.sh
+++ b/test_spark/launch_example_pyspark_shell.sh
@@ -74,7 +74,7 @@ spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.con
 # Launch a pyspark shell prompt for ppl to use
 # queue_name="--queue interactive"
 queue_name=""
-./bin/pyspark --master yarn --deploy-mode client --driver-memory 512M --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ $spark_opts_extra $queue_name
+./bin/pyspark --master yarn --deploy-mode client --driver-memory 512M --conf spark.eventLog.dir=${spark_event_log_dir}/$USER $spark_opts_extra $queue_name
 
 popd
 

--- a/test_spark/run_all_test.kerberos.sh
+++ b/test_spark/run_all_test.kerberos.sh
@@ -8,60 +8,54 @@ fi
 
 # Run the test case as alti-test-01
 # /bin/su - alti-test-01 -c "./test_spark/test_spark_shell.sh"
-all_nonkerberos_testcase=(test_spark_submit.sh test_spark_shell_graphx.sh test_spark_shell_mllib_clustering.sh test_spark_shell_mllib_classification.sh test_spark_shell_mllib_regression.sh test_spark_shell_mllib_tree.sh test_spark_sql.sh test_pyspark_sparksql.sh test_pyspark_shell.sh test_spark_hql.sh test_spark_hql.kerberos.sh test_sparksql_function.sh)
-all_kerberos_testcase=(test_spark_submit.sh test_spark_shell_graphx.sh test_spark_shell_mllib_clustering.sh test_spark_shell_mllib_classification.sh test_spark_shell_mllib_regression.sh test_spark_shell_mllib_tree.sh test_spark_sql.sh test_pyspark_sparksql.sh test_pyspark_shell.sh test_spark_hql.kerberos.sh test_sparksql_function.sh)
+all_nonkerberos_testcase=(test_spark_submit.sh test_spark_shell_graphx.sh test_spark_shell_mllib_clustering.sh test_spark_shell_mllib_classification.sh test_spark_shell_mllib_regression.sh test_spark_shell_mllib_tree.sh test_spark_sql.sh test_pyspark_sparksql.sh test_pyspark_shell.sh test_spark_hql.sh test_spark_hql.kerberos.sh test_sparksql_function.sh test_sparksql_window_function.sh)
+all_kerberos_testcase=(test_spark_submit.sh test_spark_shell_graphx.sh test_spark_shell_mllib_clustering.sh test_spark_shell_mllib_classification.sh test_spark_shell_mllib_regression.sh test_spark_shell_mllib_tree.sh test_spark_sql.sh test_pyspark_sparksql.sh test_pyspark_shell.sh test_spark_hql.kerberos.sh test_sparksql_function.sh test_sparksql_window_function.sh)
 
 curr_dir=`dirname $0`
 curr_dir=`cd $curr_dir; pwd`
 
-spark_home=$SPARK_HOME
-spark_version=$SPARK_VERSION
-
-if [ "x${spark_home}" = "x" ] ; then
-  spark_home=/opt/spark
-  echo "ok - applying default location /opt/spark"
-  if [[ ! -L "$spark_home" && ! -d "$spark_home" ]] ; then
-    >&2 echo "fail - $spark_home does not exist, can't continue, exiting! check spark installation."
-    exit -1
-  fi
-fi
-
-if [ ! -d "$spark_home/test_spark/" ] ; then
-  >&2 echo "fail - missing $spark_home/test_spark/, can't continue! Exiting!"
-  >&2 echo "fail - this script is designed for Spark general testcase only and requires test_spark directory in $spark_home"
-  >&2 echo "fail - you may create your own $spark_home/test_spark/ to reuse this script"
+export SPARK_VERSION="1.5.2"
+# Change this to your own home directory if necessary
+export SPARK_HOME="/opt/alti-spark-$SPARK_VERSION"
+# You can specify different settings for the same test case via SPARK_CONF_DIR
+export SPARK_CONF_DIR=${SPARK_CONF_DIR:-"/etc/alti-spark-$SPARK_VERSION"}
+if [ ! -d "$SPARK_CONF_DIR" ] ; then
+  >&2 echo "fail - Spark $SPARK_VERSION installation is broken, missing files or directory from $SPARK_CONF_DIR"
   exit -1
 fi
 
-source $spark_home/test_spark/init_spark.sh
-
-if [ "x${spark_version}" = "x" ] ; then
-  if [ "x${SPARK_VERSION}" = "x" ] ; then
-    >&2 echo "fail - SPARK_VERSION not set, can't continue, exiting!!!"
-    exit -1
-  else
-    spark_version=$SPARK_VERSION
-  fi
+if [[ ! -L "$SPARK_HOME" && ! -d "$SPARK_HOME" ]] ; then
+  >&2 echo "fail - $SPARK_HOME does not exist, can't continue, exiting! check spark installation."
+  exit -1
 fi
 
+if [ ! -d "$SPARK_HOME/test_spark" ] ; then
+  >&2 echo "fail - missing $SPARK_HOME/test_spark, can't continue! Exiting!"
+  >&2 echo "fail - this script is designed for Spark general testcase only and requires test_spark directory in $SPARK_HOME"
+  >&2 echo "fail - you may create your own $SPARK_HOME/test_spark to reuse this script"
+  exit -1
+fi
+
+source $SPARK_HOME/test_spark/init_spark.sh
+source $SPARK_HOME/test_spark/deploy_hive_jar.sh
 
 pushd `pwd`
-cd $spark_home
-pushd $spark_home/test_spark/
-for testcase in ${all_kerberos_testcase[*]}
-do
-  echo "ok - executing testcase $testcase"
-  ./$testcase
-  if [ $? -ne "0" ] ; then
-    >&2 echo "fail - testcase $testcase failed!!!"
-    exit -3
-  else
-    echo "ok - $testcase successsfully completed"
-  fi
-done
-popd
+  cd $SPARK_HOME
+  pushd $SPARK_HOME/test_spark
+  for testcase in ${all_kerberos_testcase[*]}
+  do
+    echo "ok - ############################################"
+    echo "ok - executing testcase $testcase"
+    echo "ok - ############################################"
+    ./$testcase
+    if [ $? -ne "0" ] ; then
+      >&2 echo "fail - testcase $testcase failed!!!"
+      exit -3
+    else
+      echo "ok - $testcase successsfully completed"
+    fi
+  done
+  popd
 popd
 
 exit 0
-
-

--- a/test_spark/run_all_test.nokerberos.sh
+++ b/test_spark/run_all_test.nokerberos.sh
@@ -8,46 +8,40 @@ fi
 
 # Run the test case as alti-test-01
 # /bin/su - alti-test-01 -c "./test_spark/test_spark_shell.sh"
-all_nonkerberos_testcase=(test_spark_submit.sh test_spark_shell_graphx.sh test_spark_shell_mllib_clustering.sh test_spark_shell_mllib_classification.sh test_spark_shell_mllib_regression.sh test_spark_shell_mllib_tree.sh test_spark_sql.sh test_pyspark_sparksql.sh test_pyspark_shell.sh test_spark_hql.sh test_spark_hql.kerberos.sh test_sparksql_function.sh)
-all_kerberos_testcase=(test_spark_submit.sh test_spark_shell_graphx.sh test_spark_shell_mllib_clustering.sh test_spark_shell_mllib_classification.sh test_spark_shell_mllib_regression.sh test_spark_shell_mllib_tree.sh test_spark_sql.sh test_pyspark_sparksql.sh test_pyspark_shell.sh test_spark_hql.kerberos.sh test_sparksql_function.sh)
+all_nonkerberos_testcase=(test_spark_submit.sh test_spark_shell_graphx.sh test_spark_shell_mllib_clustering.sh test_spark_shell_mllib_classification.sh test_spark_shell_mllib_regression.sh test_spark_shell_mllib_tree.sh test_spark_sql.sh test_pyspark_sparksql.sh test_pyspark_shell.sh test_spark_hql.sh test_spark_hql.kerberos.sh test_sparksql_function.sh test_sparksql_window_function.sh)
+all_kerberos_testcase=(test_spark_submit.sh test_spark_shell_graphx.sh test_spark_shell_mllib_clustering.sh test_spark_shell_mllib_classification.sh test_spark_shell_mllib_regression.sh test_spark_shell_mllib_tree.sh test_spark_sql.sh test_pyspark_sparksql.sh test_pyspark_shell.sh test_spark_hql.kerberos.sh test_sparksql_function.sh test_sparksql_window_function.sh)
 
 curr_dir=`dirname $0`
 curr_dir=`cd $curr_dir; pwd`
 
-spark_home=$SPARK_HOME
-spark_version=$SPARK_VERSION
-
-if [ "x${spark_home}" = "x" ] ; then
-  spark_home=/opt/spark
-  echo "ok - applying default location /opt/spark"
-  if [[ ! -L "$spark_home" && ! -d "$spark_home" ]] ; then
-    >&2 echo "fail - $spark_home does not exist, can't continue, exiting! check spark installation."
-    exit -1
-  fi
-fi
-
-if [ ! -d "$spark_home/test_spark/" ] ; then
-  >&2 echo "fail - missing $spark_home/test_spark/, can't continue! Exiting!"
-  >&2 echo "fail - this script is designed for Spark general testcase only and requires test_spark directory in $spark_home"
-  >&2 echo "fail - you may create your own $spark_home/test_spark/ to reuse this script"
+export SPARK_VERSION="1.5.2"
+# Change this to your own home directory if necessary
+export SPARK_HOME="/opt/alti-spark-$SPARK_VERSION"
+# You can specify different settings for the same test case via SPARK_CONF_DIR
+export SPARK_CONF_DIR=${SPARK_CONF_DIR:-"/etc/alti-spark-$SPARK_VERSION"}
+if [ ! -d "$SPARK_CONF_DIR" ] ; then
+  >&2 echo "fail - Spark $SPARK_VERSION installation is broken, missing files or directory from $SPARK_CONF_DIR"
   exit -1
 fi
 
-source $spark_home/test_spark/init_spark.sh
-
-if [ "x${spark_version}" = "x" ] ; then
-  if [ "x${SPARK_VERSION}" = "x" ] ; then
-    >&2 echo "fail - SPARK_VERSION not set, can't continue, exiting!!!"
-    exit -1
-  else
-    spark_version=$SPARK_VERSION
-  fi
+if [[ ! -L "$SPARK_HOME" && ! -d "$SPARK_HOME" ]] ; then
+  >&2 echo "fail - $SPARK_HOME does not exist, can't continue, exiting! check spark installation."
+  exit -1
 fi
 
+if [ ! -d "$SPARK_HOME/test_spark" ] ; then
+  >&2 echo "fail - missing $SPARK_HOME/test_spark, can't continue! Exiting!"
+  >&2 echo "fail - this script is designed for Spark general testcase only and requires test_spark directory in $SPARK_HOME"
+  >&2 echo "fail - you may create your own $SPARK_HOME/test_spark to reuse this script"
+  exit -1
+fi
+
+source $SPARK_HOME/test_spark/init_spark.sh
+source $SPARK_HOME/test_spark/deploy_hive_jar.sh
 
 pushd `pwd`
-  cd $spark_home
-  pushd $spark_home/test_spark/
+  cd $SPARK_HOME
+  pushd $SPARK_HOME/test_spark
   for testcase in ${all_nonkerberos_testcase[*]}
   do
     echo "ok - ############################################"
@@ -65,5 +59,3 @@ pushd `pwd`
 popd
 
 exit 0
-
-

--- a/test_spark/run_sparkr.sh
+++ b/test_spark/run_sparkr.sh
@@ -52,21 +52,13 @@ hdfs dfs -mkdir -p /user/$USER/spark/test/sparkr/
 hdfs dfs -put examples/src/main/resources/people.json /user/$USER/spark/test/sparkr/
 
 echo "ok - testing spark REPL shell with various algorithm"
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-# The guava JAR here does not match the Spark's pom.xml which is looking for version 14.0.1
-# Hive comes with Guava 11.0.2
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra="--jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' /etc/spark/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 
-# ./bin/spark-shell --verbose --master yarn --deploy-mode client --queue research --driver-memory 1024M --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ $spark_opts_extra << EOT
-# queue_name="--queue interactive"
-queue_name=""
+queue_name="--queue interactive"
 # Only yarn-client or local mode available (yarn-cluster mode not available)
 # Please make sure Workbench has sufficient memory for your tasks/jobs
-./bin/sparkR --verbose --driver-memory 1024M --master yarn --deploy-mode client --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ $spark_opts_extra $queue_name
+./bin/sparkR --verbose --driver-memory 1024M --master yarn --deploy-mode client --conf spark.eventLog.dir=${spark_event_log_dir}/$USER $queue_name
 
 if [ $? -ne "0" ] ; then
   echo "fail - testing SparkR shell for various algorithm failed!"

--- a/test_spark/test_data/sales
+++ b/test_spark/test_data/sales
@@ -1,0 +1,8 @@
+Mikael Akerfeltde,Sweden,300000
+Martin Mendez,Sweden,150000
+Ozzy Ozbourne,USA,200000
+Tony Iommi,USA,220000
+Jimmy Iommi,USA,220000
+Amit Tiwari,India,420000
+Rahul Tripathi,India,120000
+Sanjay Kshatriya,India,300000

--- a/test_spark/test_pyspark_shell.sh
+++ b/test_spark/test_pyspark_shell.sh
@@ -1,50 +1,43 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # Run the test case as alti-test-01
 # /bin/su - alti-test-01 -c "./test_spark/test_spark_shell.sh"
 
 curr_dir=`dirname $0`
 curr_dir=`cd $curr_dir; pwd`
-testcase_shell_file_01=$curr_dir/pysparkshell_examples.txt
-spark_home=${SPARK_HOME:='/opt/spark'}
-spark_conf=""
-spark_version=$SPARK_VERSION
-
-source $spark_home/test_spark/init_spark.sh
 
 # Default SPARK_HOME location is already checked by init_spark.sh
-if [ "x${spark_home}" = "x" ] ; then
-  spark_home=/opt/spark
-  echo "ok - applying default location $spark_home"
-elif [ ! -d "$spark_home" ] ; then
-  >&2 echo "fail - $spark_home does not exist, please check you Spark installation, exinting!"
+spark_home=${SPARK_HOME:='/opt/spark'}
+if [ ! -d "$spark_home" ] ; then
+  >&2 echo "fail - $spark_home does not exist, please check you Spark installation or SPARK_HOME env variable, exinting!"
   exit -2
 else
   echo "ok - applying Spark home $spark_home"
 fi
+
+source $spark_home/test_spark/init_spark.sh
+source $spark_home/test_spark/deploy_hive_jar.sh
+
 # Default SPARK_CONF_DIR is already checked by init_spark.sh
-spark_conf=$SPARK_CONF_DIR
-if [ "x${spark_conf}" = "x" ] ; then
-  spark_conf=/etc/spark
-elif [ ! -d "$spark_conf" ] ; then
-  >&2 echo "fail - $spark_conf does not exist, please check you Spark installation or your SPARK_CONF_DIR env, exiting!"
+spark_conf=${SPARK_CONF_DIR:-"/etc/spark"}
+if [ ! -d "$spark_conf" ] ; then
+  >&2 echo "fail - $spark_conf does not exist, please check you Spark installation or your SPARK_CONF_DIR env value, exiting!"
   exit -2
 else
   echo "ok - applying spark config directory $spark_conf"
 fi
-echo "ok - applying Spark conf $spark_conf"
- 
+
 spark_version=$SPARK_VERSION
 if [ "x${spark_version}" = "x" ] ; then
-  >&2 echo "fail - spark_version can not be identified, is end SPARK_VERSION defined? Exiting!"
+  >&2 echo "fail - SPARK_VERSION can not be identified or not defined, please review SPARK_VERSION env variable? Exiting!"
   exit -2
 fi
 
 spark_test_dir="$spark_home/test_spark"
 
-if [ ! -f "$testcase_shell_file_01"  ] ; then
-  >&2 echo "fail - missing testcase for spark, can't continue, exiting"
-  exit -2
+if [ ! -d "$spark_test_dir" ] ; then
+  echo "warn - correcting test directory from $spark_test_dir to $curr_dir"
+  spark_test_dir=$curr_dir
 fi
 
 pushd `pwd`
@@ -56,38 +49,29 @@ hdfs dfs -put $spark_home/README.md spark/test/
 hdfs dfs -put "$spark_test_dir/src/main/resources/spam_sample.txt" spark/test/
 hdfs dfs -put "$spark_test_dir/src/main/resources/normal_sample.txt" spark/test/
 
-echo "ok - testing spark REPL shell with various algorithm"
-mysql_jars=$(find /opt/mysql-connector/ -type f -name "mysql-*.jar")
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-# The guava JAR here does not match the Spark's pom.xml which is looking for version 14.0.1
-# Hive comes with Guava 11.0.2
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra="$spark_opts_extra --jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
-spark_files=$(find $hive_home/lib/ -type f -name "datanucleus*.jar" | tr -s '\n' ',')
-spark_files="$spark_files$mysql_jars,/etc/spark/hive-site.xml"
+echo "ok - testing PySpark REPL shell with various algorithm"
 
-spark_event_log_dir=$(grep 'spark.eventLog.dir' /etc/spark/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
+sparksql_hivejars="$spark_home/lib/spark-hive_${SPARK_SCALA_VERSION}.jar"
+
+spark_event_log_dir=$(grep 'spark.eventLog.dir' $spark_conf/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 
 # queue_name="--queue interactive"
 queue_name=""
-./bin/spark-submit --verbose --master yarn --deploy-mode client $spark_opts_extra $queue_name --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ --files $spark_files --py-files $spark_home/test_spark/src/main/python/pyspark_shell_examples.py $spark_home/test_spark/src/main/python/pyspark_shell_examples.py
-
-# WARNING: The following commented example will not work for PySpark shell.
-# We couldn't redirect the output to stdin for PySpark shell, so we need to submit it as a spark job.
-# ./bin/pyspark --master yarn --deploy-mode client --queue research --driver-memory 512M --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ $spark_opts_extra << EOT
-# `cat $testcase_shell_file_01`
-# EOT
+./bin/spark-submit --verbose \
+  --master yarn --deploy-mode client $queue_name \
+  --jars $spark_conf/hive-site.xml,$sparksql_hivejars \
+  --driver-class-path $spark_conf/hive-site.xml:$spark_conf/yarnclient-driver-log4j.properties \
+  --archives hdfs:///user/$USER/apps/$(basename $(readlink -f $HIVE_HOME))-lib.zip#hive \
+  --conf spark.yarn.am.extraJavaOptions="-Djava.library.path=$HADOOP_HOME/lib/native/" \
+  --conf spark.driver.extraJavaOptions="-Dlog4j.configuration=yarnclient-driver-log4j.properties -Djava.library.path=$HADOOP_HOME/lib/native/" \
+  --conf spark.eventLog.dir=${spark_event_log_dir}/$USER \
+  --py-files $spark_home/test_spark/src/main/python/pyspark_shell_examples.py \
+  $spark_home/test_spark/src/main/python/pyspark_shell_examples.py
 
 if [ $? -ne "0" ] ; then
-  >&2 echo "fail - testing shell for various MLLib algorithm failed!"
+  >&2 echo "fail - testing $0 shell for various MLLib algorithm failed!"
   exit -3
 fi
-
 popd
 
-reset
-
 exit 0
-
-

--- a/test_spark/test_pyspark_sparksql.sh
+++ b/test_spark/test_pyspark_sparksql.sh
@@ -1,48 +1,41 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # Run the test case as alti-test-01
-# /bin/su - alti-test-01 -c "./test_spark/test_spark_shell.sh"
+# /bin/su - alti-test-01 -c "./test_spark/test_pyspark_shell.sh"
 
 curr_dir=`dirname $0`
 curr_dir=`cd $curr_dir; pwd`
 
-spark_home=${SPARK_HOME:='/opt/spark'}
-spark_conf=""
-spark_version=$SPARK_VERSION
-spark_test_dir="$spark_home/test_spark"
-
-source $spark_home/test_spark/init_spark.sh
-
 # Default SPARK_HOME location is already checked by init_spark.sh
-if [ "x${spark_home}" = "x" ] ; then
-  spark_home=/opt/spark
-  echo "ok - applying default location $spark_home"
-elif [ ! -d "$spark_home" ] ; then
-  >&2 echo "fail - $spark_home does not exist, please check you Spark installation, exinting!"
+spark_home=${SPARK_HOME:='/opt/spark'}
+if [ ! -d "$spark_home" ] ; then
+  >&2 echo "fail - $spark_home does not exist, please check you Spark installation or SPARK_HOME env variable, exinting!"
   exit -2
 else
   echo "ok - applying Spark home $spark_home"
 fi
+
+source $spark_home/test_spark/init_spark.sh
+source $spark_home/test_spark/deploy_hive_jar.sh
+
 # Default SPARK_CONF_DIR is already checked by init_spark.sh
-spark_conf=$SPARK_CONF_DIR
-if [ "x${spark_conf}" = "x" ] ; then
-  spark_conf=/etc/spark
-elif [ ! -d "$spark_conf" ] ; then
-  >&2 echo "fail - $spark_conf does not exist, please check you Spark installation or your SPARK_CONF_DIR env, exiting!"
+spark_conf=${SPARK_CONF_DIR:-"/etc/spark"}
+if [ ! -d "$spark_conf" ] ; then
+  >&2 echo "fail - $spark_conf does not exist, please check you Spark installation or your SPARK_CONF_DIR env value, exiting!"
   exit -2
 else
   echo "ok - applying spark config directory $spark_conf"
 fi
-echo "ok - applying Spark conf $spark_conf"
 
 spark_version=$SPARK_VERSION
 if [ "x${spark_version}" = "x" ] ; then
-  >&2 echo "fail - spark_version can not be identified, is end SPARK_VERSION defined? Exiting!"
+  >&2 echo "fail - SPARK_VERSION can not be identified or not defined, please review SPARK_VERSION env variable? Exiting!"
   exit -2
 fi
 
-spark_test_dir=$spark_home/test_spark/
-if [ ! -f "$spark_test_dir/pom.xml" ] ; then
+spark_test_dir="$spark_home/test_spark"
+
+if [ ! -d "$spark_test_dir" ] ; then
   echo "warn - correcting test directory from $spark_test_dir to $curr_dir"
   spark_test_dir=$curr_dir
 fi
@@ -58,30 +51,24 @@ if [ ! -f "$spark_home/examples/src/main/resources/kv1.txt" ] ; then
   exit -3
 fi
 
-echo "ok - testing spark SQL shell with simple queries"
+echo "ok - testing PySpark SQL shell yarn-client mode with simple queries"
 
-app_name=`grep "<artifactId>.*</artifactId>" $spark_test_dir/pom.xml | cut -d">" -f2- | cut -d"<" -f1  | head -n 1`
-app_ver=`grep "<version>.*</version>" $spark_test_dir/pom.xml | cut -d">" -f2- | cut -d"<" -f1 | head -n 1`
-
-if [ ! -f "$spark_test_dir/${app_name}-${app_ver}.jar" ] ; then
-  >&2 echo "fail - $spark_test_dir/${app_name}-${app_ver}.jar test jar does not exist, cannot continue testing, failing!"
-  exit -3
-fi
-
-mysql_jars=$(find /opt/mysql-connector/ -type f -name "mysql-*.jar")
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra=" --jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
-spark_files=$(find $hive_home/lib/ -type f -name "datanucleus*.jar" | tr -s '\n' ',')
-spark_files="$spark_files$mysql_jars,${spark_conf}/hive-site.xml"
-
+sparksql_hivejars="$spark_home/lib/spark-hive_${SPARK_SCALA_VERSION}.jar"
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 
 # pyspark only supports yarn-client mode now
 # queue_name="--queue interactive"
 queue_name=""
-./bin/spark-submit --verbose --master yarn --deploy-mode client --driver-class-path $hadoop_lzo_jar:$hadoop_snappy_jar $queue_name $spark_opts_extra $queue_name --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ --files $spark_files --py-files $spark_home/test_spark/src/main/python/pyspark_hql.py $spark_home/test_spark/src/main/python/pyspark_hql.py
+./bin/spark-submit --verbose \
+  --master yarn --deploy-mode client $queue_name \
+  --jars $spark_conf/hive-site.xml,$sparksql_hivejars \
+  --driver-class-path $spark_conf/hive-site.xml:$spark_conf/yarnclient-driver-log4j.properties \
+  --archives hdfs:///user/$USER/apps/$(basename $(readlink -f $HIVE_HOME))-lib.zip#hive \
+  --conf spark.yarn.am.extraJavaOptions="-Djava.library.path=/opt/hadoop/lib/native/" \
+  --conf spark.driver.extraJavaOptions="-Dlog4j.configuration=yarnclient-driver-log4j.properties -Djava.library.path=/opt/hadoop/lib/native/" \
+  --conf spark.eventLog.dir=${spark_event_log_dir}/$USER \
+  --py-files $spark_home/test_spark/src/main/python/pyspark_hql.py \
+  $spark_home/test_spark/src/main/python/pyspark_hql.py
 
 if [ $? -ne "0" ] ; then
   >&2 echo "fail - testing shell for Python SparkSQL on HiveQL/HiveContext failed!!"

--- a/test_spark/test_spark_graphx.sh
+++ b/test_spark/test_spark_graphx.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # Run the test case as alti-test-01
 # /bin/su - alti-test-01 -c "./test_spark/test_spark_shell.sh"
@@ -52,12 +52,6 @@ hdfs dfs -put $spark_home/graphx/data/followers.txt spark/test/graphx/followers/
 hdfs dfs -put $spark_home/graphx/data/users.txt spark/test/graphx/followers/
 
 echo "ok - testing spark REPL shell with various algorithm"
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-# The guava JAR here does not match the Spark's pom.xml which is looking for version 14.0.1
-# Hive comes with Guava 11.0.2
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra="$spark_opts_extra --jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 SPARK_EXAMPLE_JAR=$(find ${spark_home}/examples/target/spark-examples_*-${spark_version}.jar)
@@ -65,7 +59,7 @@ SPARK_EXAMPLE_JAR=$(find ${spark_home}/examples/target/spark-examples_*-${spark_
 # Testing PageRank type
 # queue_name="--queue interactive"
 queue_name=""
-./bin/spark-submit --verbose --master yarn --deploy-mode cluster --driver-memory 2048M --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ $spark_opts_extra $queue_name --class org.apache.spark.examples.graphx.Analytics $SPARK_EXAMPLE_JAR pagerank spark/test/graphx/followers/followers.txt --numEPart=15
+./bin/spark-submit --verbose --master yarn --deploy-mode cluster --driver-memory 2048M --conf spark.eventLog.dir=${spark_event_log_dir}/$USER $queue_name --class org.apache.spark.examples.graphx.Analytics $SPARK_EXAMPLE_JAR pagerank spark/test/graphx/followers/followers.txt --numEPart=15
 
 if [ $? -ne "0" ] ; then
   >&2 echo "fail - testing GraphX spark-submit for pagerank failed!"

--- a/test_spark/test_spark_hql.sh
+++ b/test_spark/test_spark_hql.sh
@@ -1,51 +1,39 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # Run the test case as alti-test-01
 # /bin/su - alti-test-01 -c "./test_spark/test_spark_shell.sh"
-
-curr_dir=`dirname $0`
-curr_dir=`cd $curr_dir; pwd`
 spark_home=${SPARK_HOME:='/opt/spark'}
-spark_conf=""
-spark_version=$SPARK_VERSION
-spark_test_dir="$spark_home/test_spark"
-
-source $spark_home/test_spark/init_spark.sh
-
-# Default SPARK_HOME location is already checked by init_spark.sh
-if [ "x${spark_home}" = "x" ] ; then
-  spark_home=/opt/spark
-  echo "ok - applying default location $spark_home"
-elif [ ! -d "$spark_home" ] ; then
-  >&2 echo "fail - $spark_home does not exist, please check you Spark installation, exinting!"
+if [ ! -d "$spark_home" ] ; then
+  >&2 echo "fail - $spark_home does not exist, please check you Spark installation or SPARK_HOME env variable, exinting!"
   exit -2
 else
   echo "ok - applying Spark home $spark_home"
 fi
+
+source $spark_home/test_spark/init_spark.sh
+source $spark_home/test_spark/deploy_hive_jar.sh
+
 # Default SPARK_CONF_DIR is already checked by init_spark.sh
-spark_conf=$SPARK_CONF_DIR
-if [ "x${spark_conf}" = "x" ] ; then
-  spark_conf=/etc/spark
-elif [ ! -d "$spark_conf" ] ; then
-  >&2 echo "fail - $spark_conf does not exist, please check you Spark installation or your SPARK_CONF_DIR env, exiting!"
+spark_conf=${SPARK_CONF_DIR:-"/etc/spark"}
+if [ ! -d "$spark_conf" ] ; then
+  >&2 echo "fail - $spark_conf does not exist, please check you Spark installation or your SPARK_CONF_DIR env value, exiting!"
   exit -2
 else
   echo "ok - applying spark config directory $spark_conf"
 fi
-echo "ok - applying Spark conf $spark_conf"
- 
+
 spark_version=$SPARK_VERSION
 if [ "x${spark_version}" = "x" ] ; then
-  >&2 echo "fail - spark_version can not be identified, is end SPARK_VERSION defined? Exiting!"
+  >&2 echo "fail - SPARK_VERSION can not be identified or not defined, please review SPARK_VERSION env variable? Exiting!"
   exit -2
 fi
 
-hive_home=$HIVE_HOME
-if [ "x${hive_home}" = "x" ] ; then
-  hive_home=/opt/hive
-fi
+curr_dir=`dirname $0`
+curr_dir=`cd $curr_dir; pwd`
+spark_test_dir="$spark_home/test_spark"
 
-spark_test_dir=$spark_home/test_spark/
+hive_home=${HIVE_HOME:-"/opt/hive"}
+
 if [ ! -f "$spark_test_dir/pom.xml" ] ; then
   echo "warn - correcting test directory from $spark_test_dir to $curr_dir"
   spark_test_dir=$curr_dir
@@ -78,26 +66,33 @@ if [ ! -f "$spark_test_dir/${app_name}-${app_ver}.jar" ] ; then
   exit -3
 fi
 
-mysql_jars=$(find /opt/mysql-connector/ -type f -name "mysql-*.jar")
-spark_opts_extra=
-for i in `find $hive_home/lib/ -type f -name "datanucleus*.jar"`
-do
-  spark_opts_extra="$spark_opts_extra --jars $i"
-done
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-datanucleus_files=$(find $HIVE_HOME/lib/ -type f -name "datanucleus*.jar" | tr -s '\n' ',')
-spark_opts_extra="/etc/spark/hive-site.xml,${datanucleus_files}$mysql_jars,$hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
+sparksql_hivejars="$spark_home/lib/spark-hive_${SPARK_SCALA_VERSION}.jar"
+hive_jars=$sparksql_hivejars,$(find $HIVE_HOME/lib/ -type f -name "*.jar" | tr -s '\n' ',')
+hive_jars_colon=$sparksql_hivejars:$(find $HIVE_HOME/lib/ -type f -name "*.jar" | tr -s '\n' ':')
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 
 # queue_name="--queue interactive"
 queue_name=""
-./bin/spark-submit --verbose --master yarn --deploy-mode cluster --driver-memory 512M --executor-memory 2048M --executor-cores 3 --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ --driver-java-options "-XX:MaxPermSize=1024M -Djava.library.path=/opt/hadoop/lib/native/" --driver-class-path hive-site.xml $queue_name --jars $spark_opts_extra --class SparkSQLTestCase2HiveContextYarnClusterApp $spark_test_dir/${app_name}-${app_ver}.jar
+
+# if /etc/spark/spark-env.sh already defined the SPARK_DIST_CLASSPATH for you for the spark-hive
+# or spark-hive-thriftserver name in the executor classpath, the spark.executor.extraClassPath here is redundant.
+# The spark.executor.extraClassPath here is just for demonstration, and explicitly telling people you 
+# need to be aware of this for the executor classpath
+./bin/spark-submit --verbose \
+  --master yarn --deploy-mode cluster \
+  --jars $spark_conf/hive-site.xml,$sparksql_hivejars \
+  --archives hdfs:///user/$USER/apps/$(basename $(readlink -f $HIVE_HOME))-lib.zip#hive \
+  --driver-memory 512M --executor-memory 2048M --executor-cores 3 \
+  --driver-class-path hive-site.xml:yarncluster-driver-log4j.properties $queue_name \
+  --conf spark.driver.extraJavaOptions="-XX:MaxPermSize=1024M -Dlog4j.configuration=yarncluster-driver-log4j.properties -Djava.library.path=$HADOOP_HOME/lib/native/" \
+  --conf spark.eventLog.dir=${spark_event_log_dir}/$USER \
+  --conf spark.yarn.preserve.staging.files=true \
+  --class SparkSQLTestCase2HiveContextYarnClusterApp \
+  $spark_test_dir/${app_name}-${app_ver}.jar
 
 if [ $? -ne "0" ] ; then
-  >&2 echo "fail - testing shell for SparkSQL on HiveQL/HiveContext failed!!"
+  >&2 echo "fail - testing $0 for SparkSQL on HiveQL/HiveContext failed!!"
   exit -4
 fi
 

--- a/test_spark/test_spark_shell.sh
+++ b/test_spark/test_spark_shell.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # Run the test case as alti-test-01
 # /bin/su - alti-test-01 -c "./test_spark/test_spark_shell.sh"
@@ -64,18 +64,13 @@ hdfs dfs -mkdir -p spark/test/naive_bayes
 hdfs dfs -put ${spark_home}/mllib/data/sample_naive_bayes_data.txt spark/test/naive_bayes/
 
 echo "ok - testing spark REPL shell with various algorithm"
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-# The guava JAR here does not match the Spark's pom.xml which is looking for version 14.0.1
-# Hive comes with Guava 11.0.2
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra="$spark_opts_extra --jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
+spark_opts_extra=""
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 
 # queue_name="--queue interactive"
 queue_name=""
-./bin/spark-shell --verbose --master yarn --deploy-mode client --driver-memory 1024M --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ $spark_opts_extra $queue_name << EOT
+./bin/spark-shell --verbose --master yarn --deploy-mode client --driver-memory 1024M --conf spark.eventLog.dir=${spark_event_log_dir}/$USER $spark_opts_extra $queue_name << EOT
 `cat $testcase_shell_file_01`
 EOT
 

--- a/test_spark/test_spark_shell_graphx.sh
+++ b/test_spark/test_spark_shell_graphx.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # Run the test case as alti-test-01
 # /bin/su - alti-test-01 -c "./test_spark/test_spark_shell.sh"
@@ -51,19 +51,13 @@ hdfs dfs -mkdir -p spark/test/graphx/followers
 hdfs dfs -put ${spark_home}/graphx/data/followers.txt spark/test/graphx/followers/
 hdfs dfs -put ${spark_home}/graphx/data/users.txt spark/test/graphx/followers/
 
-echo "ok - testing spark REPL shell with various algorithm"
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-# The guava JAR here does not match the Spark's pom.xml which is looking for version 14.0.1
-# Hive comes with Guava 11.0.2
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra="$spark_opts_extra --jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
+echo "ok - testing spark REPL shell with GraphX's algorithm"
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 
 # queue_name="--queue interactive"
 queue_name=""
-./bin/spark-shell --verbose --master yarn --deploy-mode client --driver-memory 1536M --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ $spark_opts_extra $queue_name << EOT
+./bin/spark-shell --verbose --master yarn --deploy-mode client --driver-memory 1536M --conf spark.eventLog.dir=${spark_event_log_dir}/$USER $queue_name << EOT
 `cat $testcase_shell_file_01`
 EOT
 

--- a/test_spark/test_spark_shell_mllib_classification.sh
+++ b/test_spark/test_spark_shell_mllib_classification.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # Run the test case as alti-test-01
 # /bin/su - alti-test-01 -c "./test_spark/test_spark_shell.sh"
@@ -56,19 +56,13 @@ hdfs dfs -put $spark_home/mllib/data/sample_libsvm_data.txt spark/test/logistic_
 # To create local directory when generating PMML XML file locally on workbench
 mkdir -p /tmp/spark_pmml_test/
 
-echo "ok - testing spark REPL shell with various algorithm"
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-# The guava JAR here does not match the Spark's pom.xml which is looking for version 14.0.1
-# Hive comes with Guava 11.0.2
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra="$spark_opts_extra --jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
+echo "ok - testing spark REPL shell with Classification algorithm"
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 
 # queue_name="--queue interactive"
 queue_name=""
-./bin/spark-shell --verbose --master yarn --deploy-mode client --driver-memory 1024M --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ $spark_opts_extra $queue_name << EOT
+./bin/spark-shell --verbose --master yarn --deploy-mode client --driver-memory 1024M --conf spark.eventLog.dir=${spark_event_log_dir}/$USER $queue_name << EOT
 `cat $testcase_shell_file_01`
 EOT
 

--- a/test_spark/test_spark_shell_mllib_clustering.sh
+++ b/test_spark/test_spark_shell_mllib_clustering.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # Run the test case as alti-test-01
 # /bin/su - alti-test-01 -c "./test_spark/test_spark_shell.sh"
@@ -58,19 +58,13 @@ hdfs dfs -put $spark_home/mllib/data/kmeans/kmeans_data.txt spark/test/kmean/
 # To create local directory when generating PMML XML file locally on workbench
 mkdir -p /tmp/spark_pmml_test/
 
-echo "ok - testing spark REPL shell with various algorithm"
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-# The guava JAR here does not match the Spark's pom.xml which is looking for version 14.0.1
-# Hive comes with Guava 11.0.2
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra="$spark_opts_extra --jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
+echo "ok - testing spark REPL shell with Clustering algorithm"
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 
 # queue_name="--queue interactive"
 queue_name=""
-./bin/spark-shell --verbose --master yarn --deploy-mode client --driver-memory 1024M --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ $spark_opts_extra $queue_name << EOT
+./bin/spark-shell --verbose --master yarn --deploy-mode client --driver-memory 1024M --conf spark.eventLog.dir=${spark_event_log_dir}/$USER $queue_name << EOT
 `cat $testcase_shell_file_01`
 EOT
 

--- a/test_spark/test_spark_shell_mllib_regression.sh
+++ b/test_spark/test_spark_shell_mllib_regression.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # Run the test case as alti-test-01
 # /bin/su - alti-test-01 -c "./test_spark/test_spark_shell.sh"
@@ -51,19 +51,13 @@ hdfs dfs -put $spark_home/mllib/data/ridge-data/lpsa.data spark/test/linear_regr
 # To create local directory when generating PMML XML file locally on workbench
 mkdir -p /tmp/spark_pmml_test/
 
-echo "ok - testing spark REPL shell with various algorithm"
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-# The guava JAR here does not match the Spark's pom.xml which is looking for version 14.0.1
-# Hive comes with Guava 11.0.2
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra="$spark_opts_extra --jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
+echo "ok - testing spark REPL shell with Regression algorithm"
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 
 # queue_name="--queue interactive"
 queue_name=""
-./bin/spark-shell --verbose --master yarn --deploy-mode client --driver-memory 1024M --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ $spark_opts_extra  $queue_name << EOT
+./bin/spark-shell --verbose --master yarn --deploy-mode client --driver-memory 1024M --conf spark.eventLog.dir=${spark_event_log_dir}/$USER $queue_name << EOT
 `cat $testcase_shell_file_01`
 EOT
 

--- a/test_spark/test_spark_shell_mllib_tree.sh
+++ b/test_spark/test_spark_shell_mllib_tree.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # Run the test case as alti-test-01
 # /bin/su - alti-test-01 -c "./test_spark/test_spark_shell.sh"
@@ -52,19 +52,13 @@ hdfs dfs -put $spark_home/mllib/data/sample_tree_data.csv spark/test/decision_tr
 # To create local directory when generating PMML XML file locally on workbench
 mkdir -p /tmp/spark_pmml_test/
 
-echo "ok - testing spark REPL shell with various algorithm"
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-# The guava JAR here does not match the Spark's pom.xml which is looking for version 14.0.1
-# Hive comes with Guava 11.0.2
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra="$spark_opts_extra --jars $hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar"
+echo "ok - testing spark REPL shell with Decision Tree algorithm"
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 
 # queue_name="--queue interactive"
 queue_name=""
-./bin/spark-shell --verbose --master yarn --deploy-mode client --driver-memory 1024M --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ $spark_opts_extra $queue_name << EOT
+./bin/spark-shell --verbose --master yarn --deploy-mode client --driver-memory 1024M --conf spark.eventLog.dir=${spark_event_log_dir}/$USER $queue_name << EOT
 `cat $testcase_shell_file_01`
 EOT
 

--- a/test_spark/test_spark_sql.sh
+++ b/test_spark/test_spark_sql.sh
@@ -1,43 +1,36 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # Run the test case as alti-test-01
 # /bin/su - alti-test-01 -c "./test_spark/test_spark_shell.sh"
 
-curr_dir=`dirname $0`
-curr_dir=`cd $curr_dir; pwd`
-spark_home=${SPARK_HOME:='/opt/spark'}
-spark_conf=""
-spark_version=$SPARK_VERSION
-
-source $spark_home/test_spark/init_spark.sh
-
 # Default SPARK_HOME location is already checked by init_spark.sh
-if [ "x${spark_home}" = "x" ] ; then
-  spark_home=/opt/spark
-  echo "ok - applying default location $spark_home"
-elif [ ! -d "$spark_home" ] ; then
-  >&2 echo "fail - $spark_home does not exist, please check you Spark installation, exinting!"
+spark_home=${SPARK_HOME:='/opt/spark'}
+if [ ! -d "$spark_home" ] ; then
+  >&2 echo "fail - $spark_home does not exist, please check you Spark installation or SPARK_HOME env variable, exinting!"
   exit -2
 else
   echo "ok - applying Spark home $spark_home"
-fi  
+fi
+
+source $spark_home/test_spark/init_spark.sh
+
 # Default SPARK_CONF_DIR is already checked by init_spark.sh
-spark_conf=$SPARK_CONF_DIR
-if [ "x${spark_conf}" = "x" ] ; then
-  spark_conf=/etc/spark
-elif [ ! -d "$spark_conf" ] ; then
-  >&2 echo "fail - $spark_conf does not exist, please check you Spark installation or your SPARK_CONF_DIR env, exiting!"
+spark_conf=${SPARK_CONF_DIR:-"/etc/spark"}
+if [ ! -d "$spark_conf" ] ; then
+  >&2 echo "fail - $spark_conf does not exist, please check you Spark installation or your SPARK_CONF_DIR env value, exiting!"
   exit -2
 else
   echo "ok - applying spark config directory $spark_conf"
 fi
-echo "ok - applying Spark conf $spark_conf"
-  
+
 spark_version=$SPARK_VERSION
 if [ "x${spark_version}" = "x" ] ; then
-  >&2 echo "fail - spark_version can not be identified, is end SPARK_VERSION defined? Exiting!"
+  >&2 echo "fail - SPARK_VERSION can not be identified or not defined, please review SPARK_VERSION env variable? Exiting!"
   exit -2
 fi
+
+curr_dir=`dirname $0`
+curr_dir=`cd $curr_dir; pwd`
 
 if [ -f "$curr_dir/pom.xml" ] ; then
   spark_test_dir=$curr_dir
@@ -64,10 +57,15 @@ spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.con
 
 # queue_name="--queue interactive"
 queue_name=""
-./bin/spark-submit --verbose --master yarn --deploy-mode cluster --driver-java-options "-Djava.library.path=/opt/hadoop/lib/native/" --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ $queue_name --class SparkSQLTestCase1SQLContextApp $spark_test_dir/${app_name}-${app_ver}.jar
+./bin/spark-submit --verbose \
+  --master yarn --deploy-mode cluster \
+  --driver-java-options "-Djava.library.path=/opt/hadoop/lib/native/" \
+  --conf spark.eventLog.dir=${spark_event_log_dir}/$USER $queue_name \
+  --class SparkSQLTestCase1SQLContextApp \
+  $spark_test_dir/${app_name}-${app_ver}.jar
 
 if [ $? -ne "0" ] ; then
-  >&2 echo "fail - testing shell for SparkSQL SQLContext failed!!"
+  >&2 echo "fail - testing $0 for SparkSQL SQLContext failed!!"
   exit -4
 fi
 

--- a/test_spark/test_spark_submit.sh
+++ b/test_spark/test_spark_submit.sh
@@ -1,50 +1,43 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # Run the test case as alti-test-01
 # /bin/su - alti-test-01 -c "./test_spark/test_spark_shell.sh"
 
-curr_dir=`dirname $0`
-curr_dir=`cd $curr_dir; pwd`
-spark_home=${SPARK_HOME:='/opt/spark'}
-spark_conf=""
-spark_version=$SPARK_VERSION
-
-source $spark_home/test_spark/init_spark.sh
-
 # Default SPARK_HOME location is already checked by init_spark.sh
-if [ "x${spark_home}" = "x" ] ; then
-  spark_home=/opt/spark
-  echo "ok - applying default location $spark_home"
-elif [ ! -d "$spark_home" ] ; then
-  >&2 echo "fail - $spark_home does not exist, please check you Spark installation, exinting!"
+spark_home=${SPARK_HOME:='/opt/spark'}
+if [ ! -d "$spark_home" ] ; then
+  >&2 echo "fail - $spark_home does not exist, please check you Spark installation or SPARK_HOME env variable, exinting!"
   exit -2
 else
   echo "ok - applying Spark home $spark_home"
-fi  
+fi
+
+source $spark_home/test_spark/init_spark.sh
+
 # Default SPARK_CONF_DIR is already checked by init_spark.sh
-spark_conf=$SPARK_CONF_DIR
-if [ "x${spark_conf}" = "x" ] ; then
-  spark_conf=/etc/spark
-elif [ ! -d "$spark_conf" ] ; then
-  >&2 echo "fail - $spark_conf does not exist, please check you Spark installation or your SPARK_CONF_DIR env, exiting!"
+spark_conf=${SPARK_CONF_DIR:-"/etc/spark"}
+if [ ! -d "$spark_conf" ] ; then
+  >&2 echo "fail - $spark_conf does not exist, please check you Spark installation or your SPARK_CONF_DIR env value, exiting!"
   exit -2
 else
   echo "ok - applying spark config directory $spark_conf"
 fi
-echo "ok - applying Spark conf $spark_conf"
-  
+
 spark_version=$SPARK_VERSION
 if [ "x${spark_version}" = "x" ] ; then
-  >&2 echo "fail - spark_version can not be identified, is end SPARK_VERSION defined? Exiting!"
+  >&2 echo "fail - SPARK_VERSION can not be identified or not defined, please review SPARK_VERSION env variable? Exiting!"
   exit -2
 fi
+
+curr_dir=`dirname $0`
+curr_dir=`cd $curr_dir; pwd`
 
 pushd `pwd`
 cd $spark_home
 
 echo "ok - testing spark REPL shell with various algorithm"
 
-SPARK_EXAMPLE_JAR=$(find ${spark_home}/examples/target/spark-examples_*-${spark_version}.jar)
+SPARK_EXAMPLE_JAR=$(find ${spark_home}/lib/spark-examples_*-${spark_version}.jar)
 
 if [ ! -f "${SPARK_EXAMPLE_JAR}" ] ; then
   >&2 echo "fail - cannot detect example jar for this $spark_version $spark_installed build!"
@@ -55,10 +48,16 @@ spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.con
 
 # queue_name="--queue interactive"
 queue_name=""
-./bin/spark-submit --verbose --master yarn --deploy-mode cluster $queue_name --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ --class org.apache.spark.examples.SparkPi "${SPARK_EXAMPLE_JAR}"
+./bin/spark-submit --verbose \
+  --master yarn --deploy-mode cluster $queue_name \
+  --conf spark.eventLog.dir=${spark_event_log_dir}/$USER \
+  --conf spark.driver.extraJavaOptions="-Dlog4j.configuration=yarncluster-driver-log4j.properties" \
+  --conf spark.driver.extraClassPath=yarncluster-driver-log4j.properties \
+  --class org.apache.spark.examples.SparkPi \
+  "${SPARK_EXAMPLE_JAR}"
 
 if [ $? -ne "0" ] ; then
-  >&2 echo "fail - testing shell for various algorithm failed!"
+  >&2 echo "fail - testing $0 for various algorithm failed!"
   exit -3
 fi
 

--- a/test_spark/test_spark_thriftserver2.sh
+++ b/test_spark/test_spark_thriftserver2.sh
@@ -1,50 +1,44 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # Run the test case as spark
 # We will use beeline to test it via the JDBC driver
 # /bin/su - spark -c "./test_spark/test_spark_thriftserver2.sh"
 
-curr_dir=`dirname $0`
-curr_dir=`cd $curr_dir; pwd`
-spark_logs=""
-spark_home=${SPARK_HOME:='/opt/spark'}
-spark_conf=""
-spark_version=$SPARK_VERSION
-
-source $spark_home/test_spark/init_spark.sh
-
 # Default SPARK_HOME location is already checked by init_spark.sh
-if [ "x${spark_home}" = "x" ] ; then
-  spark_home=/opt/spark
-  echo "ok - applying default location $spark_home"
-elif [ ! -d "$spark_home" ] ; then
-  >&2 echo "fail - $spark_home does not exist, please check you Spark installation, exinting!"
+spark_home=${SPARK_HOME:='/opt/spark'}
+if [ ! -d "$spark_home" ] ; then
+  >&2 echo "fail - $spark_home does not exist, please check you Spark installation or SPARK_HOME env variable, exinting!"
   exit -2
 else
   echo "ok - applying Spark home $spark_home"
 fi
+
+source $spark_home/test_spark/init_spark.sh
+
 # Default SPARK_CONF_DIR is already checked by init_spark.sh
-spark_conf=$SPARK_CONF_DIR
-if [ "x${spark_conf}" = "x" ] ; then
-  spark_conf=/etc/spark
-elif [ ! -d "$spark_conf" ] ; then
-  >&2 echo "fail - $spark_conf does not exist, please check you Spark installation or your SPARK_CONF_DIR env, exiting!"
+spark_conf=${SPARK_CONF_DIR:-"/etc/spark"}
+if [ ! -d "$spark_conf" ] ; then
+  >&2 echo "fail - $spark_conf does not exist, please check you Spark installation or your SPARK_CONF_DIR env value, exiting!"
   exit -2
 else
   echo "ok - applying spark config directory $spark_conf"
 fi
-echo "ok - applying Spark conf $spark_conf"
 
 spark_version=$SPARK_VERSION
 if [ "x${spark_version}" = "x" ] ; then
-  >&2 echo "fail - spark_version can not be identified, is end SPARK_VERSION defined? Exiting!"
+  >&2 echo "fail - SPARK_VERSION can not be identified or not defined, please review SPARK_VERSION env variable? Exiting!"
   exit -2
 fi
 
-spark_ts2_listen_port=20000
+curr_dir=`dirname $0`
+curr_dir=`cd $curr_dir; pwd`
+spark_logs=""
+spark_test_dir="$spark_home/test_spark"
+
+spark_ts2_listen_port=48600
 running_user=`whoami`
-# This needs to align with /etc/spark/log4j.properties
-spark_logs=${HOME}/Hadooplogs/spark/logs/spark.log
+# This needs to align with /etc/spark/yarnclient-driver-log4j.properties
+spark_logs=${HOME}/Hadooplogs/spark/logs/spark-driver.log
 
 # Just inherit what is defined in spark-daemon.sh and load-spark-env.sh and /etc/spark/spark-env.sh
 # if [ "$SPARK_IDENT_STRING" = "" ]; then
@@ -56,26 +50,35 @@ fi
 
 pushd `pwd`
 cd $spark_home/sbin/
-mysql_jars=$(find /opt/mysql-connector/ -type f -name "mysql-*.jar")
-spark_opts_extra=
-for i in `find $hive_home/lib/ -type f -name "datanucleus*.jar"`
-do
-  spark_opts_extra="$spark_opts_extra $i"
-done
-hadoop_snappy_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "snappy-java-*.jar")
-hadoop_lzo_jar=$(find $HADOOP_HOME/share/hadoop/common/lib/ -type f -name "hadoop-lzo-*.jar")
-guava_jar=$(find $HIVE_HOME/lib/ -type f -name "guava-*.jar")
-spark_opts_extra=$(echo "$spark_opts_extra $mysql_jars,$hadoop_lzo_jar,$hadoop_snappy_jar,$guava_jar" | tr -s ' ' ' ' | tr -s ' ' ',')
 
-spark_files=$(find $hive_home/lib/ -type f -name "datanucleus*.jar" | tr -s '\n' ',')
-spark_files="$spark_files$mysql_jars,$spark_conf/hive-site.xml"
-
+sparksql_hivejars="$spark_home/lib/spark-hive_${SPARK_SCALA_VERSION}.jar"
+sparksql_hivethriftjars="$spark_home/lib/spark-hive-thriftserver_${SPARK_SCALA_VERSION}.jar"
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 
 echo "ok - starting thriftserver"
 
-ret=$(./start-thriftserver.sh --jars $spark_opts_extra --files $spark_files --hiveconf hive.server2.thrift.port=$spark_ts2_listen_port --hiveconf hive.server2.thrift.bind.host=$(hostname) --master yarn-client --queue research --executor-memory 1G --num-executors 4 --executor-cores 2 --driver-memory 1G --conf spark.locality.wait=10000 --conf spark.shuffle.manager=sort --conf spark.shuffle.consolidateFiles=true --conf spark.rdd.compress=true --conf spark.storage.memoryFraction=0.6 --conf spark.sql.inMemoryColumnarStorage.compressed=true --conf spark.sql.inMemoryColumnarStorage.batchSize=10240 --conf spark.eventLog.dir=${spark_event_log_dir}$USER/)
+ret=$(./start-thriftserver.sh --verbose \
+  --master yarn-client \
+  --driver-class-path $spark_conf/hive-site.xml:$spark_conf/yarnclient-driver-log4j.properties \
+  --jars $spark_conf/hive-site.xml,$sparksql_hivejars,$sparksql_hivethriftjars \
+  --archives hdfs:///user/$USER/apps/$(basename $(readlink -f $HIVE_HOME))-lib.zip#hive \
+  --conf spark.yarn.am.extraJavaOptions="-Djava.library.path=$HADOOP_HOME/lib/native/" \
+  --conf spark.driver.extraJavaOptions="-Dlog4j.configuration=yarnclient-driver-log4j.properties -Djava.library.path=$HADOOP_HOME/lib/native/" \
+  --conf spark.executor.extraJavaOptions="-Dlog4j.configuration=executor-log4j.properties -XX:+PrintReferenceGC -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintAdaptiveSizePolicy -Djava.library.path=$HADOOP_HOME/lib/native/" \
+  --executor-memory 1G \
+  --num-executors 4 \
+  --executor-cores 2 \
+  --driver-memory 1G \
+  --conf spark.eventLog.dir=${spark_event_log_dir}/$USER \
+  --conf spark.locality.wait=10000 \
+  --conf spark.shuffle.manager=sort \
+  --conf spark.shuffle.consolidateFiles=true \
+  --conf spark.rdd.compress=true \
+  --conf spark.sql.inMemoryColumnarStorage.compressed=true \
+  --conf spark.sql.inMemoryColumnarStorage.batchSize=10240 \
+  --hiveconf hive.server2.thrift.port=$spark_ts2_listen_port \
+  --hiveconf hive.server2.thrift.bind.host=$(hostname))
 if [ $? -ne "0" ] ; then
   >&2 echo "fail - can't start thriftserver, something went wrong, see $ret"
   exit -3
@@ -98,12 +101,13 @@ ts2_yarn_app_id=""
 log_check_ts2="true"
 pid_check_ts2="true"
 nc_check_ts2="true"
+
 # TBD: This is not a good way to check if it is up and running, however, it's a start. Can check PID, etc as well.
 start_log_line=$(grep -n "Starting SparkContext" $spark_logs | tail -n 1 | cut -d":" -f1)
 if [ "x${start_log_line}" = "x" ] ; then
-  >&2 echo "warn - log rotated so fast? can't find the starting string to search for."
+  >&2 echo "warn - log rotated so fast? can't find the starting string 'Starting SparkContext' to search for in $spark_logs"
 else
-  ts2_ret_str=$(tail -n +${start_log_line} $spark_logs | grep -i 'ThriftBinaryCLIService listening on')
+  ts2_ret_str=$(tail -n +${start_log_line} $spark_logs | grep -i 'Starting ThriftBinaryCLIService on port')
   ts2_yarn_app_id=$(tail -n +${start_log_line} $spark_logs | grep -io 'Submitted application .*' | tail -n 1 | cut -d" " -f3)
   if [ "x${ts2_ret_str}" = "x" ] ; then
     >&2 echo "fail - something is wrong, can't detect service listening string 'ThriftBinaryCLIService listening on', the service is taking longer then 60 seconds to start? This is odd on a fresh VPC, please manually check Spark TS2!"
@@ -116,6 +120,7 @@ fi
 nc_ret=$(netstat -lt | grep $spark_ts2_listen_port)
 if [ "x${nc_ret}" = "x" ] ; then
   nc_check_ts2="false"
+  >&2 echo "fail - couldn't locate network port $spark_ts2_listen_port for Spark TS2"
 fi
 
 spark_pid=$(cat $spark_ts2_pid_str | tr -d '\n')
@@ -126,6 +131,12 @@ if [ "x${pid_ret}" = "x0" ] ; then
 else
   echo "ok - Spark ThriftServer2 PID $spark_pid found"
 fi
+
+echo "ok - =========================================="
+echo "ok - you may execute \"yarn logs -applicationId ${ts2_yarn_app_id}\" to inspect executor logs"
+echo "ok - or inspect $spark_logs for spark driver logs"
+echo "ok - =========================================="
+sleep 3
 
 if [ "x${log_check_ts2}" = "false" -a "x${log_check_ts2}" = "false" -a "x${pid_check_ts2}" = "xfalse" ] ; then
   >&2 echo "fail - all pid check, log check and port check failed, Spark ThriftServer2 is not running, stopping it, and please check!"
@@ -154,19 +165,48 @@ else
   echo "ok - query Hive table spark_hive_test_yarn_cluster_table successfully, we see: $jdbc_ret"
 fi
 
+table_uuid=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 12 | head -n 1)
+db_name="spark_test_db_${table_uuid}"
+table_name="spark_hive_test_table_${table_uuid}"
+new_table_name="new_spark_hive_test_table_${table_uuid}"
+orc_table_name="orc_spark_hive_test_table_${table_uuid}"
+parquet_table_name="parquet_spark_hive_test_table_${table_uuid}"
+
+test_create_database_sql1="CREATE DATABASE IF NOT EXISTS ${db_name}"
+test_create_table_sql1="CREATE TABLE $table_name (key INT, value STRING) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE"
+test_alter_table_sql1="ALTER TABLE $table_name RENAME TO $new_table_name"
+test_describe_table_sql1="DESCRIBE FORMATTED $new_table_name"
+test_truncate_table_sql1="TRUNCATE TABLE $new_table_name"
+test_load_data_sql1="LOAD DATA LOCAL INPATH '${spark_test_dir}/test_data/sparksql_testdata2.csv' INTO TABLE $new_table_name"
+test_select_sql1="SELECT SUM(key) FROM $new_table_name"
+# Only works with Hive 1.2.x. Bug on Hive 0.13.1
+test_create_orc_sql1="CREATE TABLE $orc_table_name STORED AS ORC AS SELECT key,value FROM $new_table_name"
+test_create_parquet_sql1="CREATE TABLE $parquet_table_name STORED AS PARQUET AS SELECT * FROM $new_table_name"
+test_select_orc_sql1="SELECT SUM(key) FROM $orc_table_name"
+test_select_parquet_sql1="SELECT SUM(key) FROM $parquet_table_name"
+test_drop_table_sql1="DROP TABLE $new_table_name"
+test_drop_orc_table_sql1="DROP TABLE $orc_table_name"
+test_drop_parquet_table_sql1="DROP TABLE $parquet_table_name"
+test_drop_database_sql1="DROP DATABASE IF EXISTS ${db_name}"
+
+jdbc_ret=$(beeline -u "jdbc:hive2://$(hostname):$spark_ts2_listen_port" -n alti-test-01 -p "" -e "$test_create_database_sql1; USE $db_name; $test_create_table_sql1 ; $test_alter_table_sql1 ; $test_describe_table_sql1; $test_truncate_table_sql1 ; $test_load_data_sql1 ; $test_create_orc_sql1; $test_create_parquet_sql1; $test_select_sql1 ; $test_select_orc_sql1; $test_select_parquet_sql1; $test_drop_table_sql1 ; $test_drop_orc_table_sql1; $test_drop_parquet_table_sql1; $test_drop_database_sql1; " 2>&1)
+error_str=$(echo $jdbc_ret | grep -io "Error:" | head -n 1 | tr [:upper:] [:lower:])
+if [ "x${error_str}" = "xerror:" ] ; then
+  >&2 echo "fail - beeline can't query hive table spark_hive_test_yarn_cluster_table via Spark ThriftServer2 due to $jdbc_ret"
+else
+  echo "ok - query Hive table spark_hive_test_yarn_cluster_table successfully, we see: $jdbc_ret"
+fi
+
 # Done testing, stop the service. Not expecting a lot of data from YARN log
 ./stop-thriftserver.sh
 yarn_ret=$(2>/dev/null yarn application -status $ts2_yarn_app_id | grep 'State : FINISHED' | tr -d '\t' | tr -d ' ' | tr [:upper:] [:lower:] | head -n 1)
 if [ "x${yarn_ret}" = "xstate:finished" ] ; then
-  echo "ok - test completed, printing last 100 lines from YARN log for record"
-  yarn logs -applicationId $ts2_yarn_app_id | tail -n 100
+  echo "ok - test completed, printing last 100 lines from Spark TS's Driver log for record"
+  popd
+  exit 0
 else
   >&2 echo "fail - Spark TS2 YARN application did not end with State FINISHED, something is wrong, printing all logs for debugging!"
-  yarn logs -applicationId $ts2_yarn_app_id
+  >&2 echo "fail - you may execute \"yarn logs -applicationId ${ts2_yarn_app_id}\" to inspect executor logs, and $spark_logs for spark driver logs"
+  popd
+  exit -9
 fi
-
-popd
-
-exit 0
-
-

--- a/test_spark/test_sparkr.localmode.sh
+++ b/test_spark/test_sparkr.localmode.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # Run the test case as alti-test-01
 # /bin/su - alti-test-01 -c "./test_spark/test_spark_shell.sh"
@@ -63,7 +63,7 @@ spark_event_log_dir=$(grep 'spark.eventLog.dir' ${spark_conf}/spark-defaults.con
 # queue_name=""
 # SPARK-6797 SparkR does not support YARN (yarn-client, yarn-cluster), only local mode available
 # Please make sure Workbench has sufficient memory for your tasks/jobs
-./bin/sparkR --verbose --driver-memory 1024M --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ $spark_opts_extra
+./bin/sparkR --verbose --driver-memory 1024M --conf spark.eventLog.dir=${spark_event_log_dir}/$USER $spark_opts_extra
 
 if [ $? -ne "0" ] ; then
   >&2 echo "fail - testing SparkR shell for various algorithm failed!"

--- a/test_spark/test_sparkr.sh
+++ b/test_spark/test_sparkr.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # Run the test case as alti-test-01
 # /bin/su - alti-test-01 -c "./test_spark/test_spark_shell.sh"

--- a/test_spark/test_sparksql_shell.sh
+++ b/test_spark/test_sparksql_shell.sh
@@ -78,10 +78,9 @@ spark_files="$spark_files$mysql_jars,/etc/spark/hive-site.xml"
 
 spark_event_log_dir=$(grep 'spark.eventLog.dir' /etc/spark/spark-defaults.conf | tr -s ' ' '\t' | cut -f2)
 
-# ./bin/spark-sql --verbose --queue research --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ --driver-java-options "-XX:MaxPermSize=1024M -Djava.library.path=/opt/hadoop/lib/native/" --driver-class-path hive-site.xml --master yarn --deploy-mode client --driver-memory 512M --executor-memory 1G --executor-cores 2 $spark_opts_extra 
 # queue_name="--queue interactive"
 queue_name=""
-./bin/spark-sql --verbose --master yarn --deploy-mode client --driver-memory 512M --executor-memory 1G --executor-cores 2 --conf spark.eventLog.dir=${spark_event_log_dir}$USER/ --driver-java-options "-XX:MaxPermSize=1024M -Djava.library.path=/opt/hadoop/lib/native/" --driver-class-path hive-site.xml $spark_opts_extra $queue_name
+./bin/spark-sql --verbose --master yarn --deploy-mode client --driver-memory 512M --executor-memory 1G --executor-cores 2 --conf spark.eventLog.dir=${spark_event_log_dir}/$USER --driver-java-options "-XX:MaxPermSize=1024M -Djava.library.path=/opt/hadoop/lib/native/" --driver-class-path hive-site.xml $spark_opts_extra $queue_name
 
 if [ $? -ne "0" ] ; then
   >&2 echo "fail - testing shell for SparkSQL on HiveQL/HiveContext failed!!"


### PR DESCRIPTION
Backport the following from Spark 1.6.1 to 1.5.2.

AE-2021: Provide smooth upgrade solution, utilize SPARK_HOME/lib
directory for assembly jar without hadoop version string

SI-695: Apply customized log4j properties for yarn-client and
yarn-cluster mode respectively. Default output will point to console
which will be captured by YARN container logs. Spark driver logs
will now go to spark-driver.log and executor logs will go to
spark-executor.log.

AE-2048: Update spark-env.sh to include Hive JARs in classpath and
distribute them for both yarn-client and yarn-cluster mode. This
still requires user to upload Hive JARs via the --jars option, however,
they no longer need to specify the lengthy classpath in SparkConf.
