### PR TITLE
AE-2745: Add DEBUG_MAVEN env flag

### DIFF
--- a/scripts/justbuild.sh
+++ b/scripts/justbuild.sh
@@ -123,7 +123,13 @@ fi
 #   mvn_release_flag="-Psnapshots"
 # fi
 
-mvn_cmd="mvn -U -X $hadoop_profile_str -Phive-thriftserver -Phadoop-provided -Phive-provided -Psparkr -Pyarn -Pkinesis-asl -DskipTests install"
+DEBUG_MAVEN=false
+if [ "x${DEBUG_MAVEN}" = "xtrue" ] ; then
+  mvn_cmd="mvn -U -X $hadoop_profile_str -Phive-thriftserver -Phadoop-provided -Phive-provided -Psparkr -Pyarn -Pkinesis-asl -DskipTests install"
+else
+  mvn_cmd="mvn -U $hadoop_profile_str -Phive-thriftserver -Phadoop-provided -Phive-provided -Psparkr -Pyarn -Pkinesis-asl -DskipTests install"
+fi
+
 echo "$mvn_cmd"
 $mvn_cmd
 


### PR DESCRIPTION
Default is to suppress all the debug logs from maven. User can enable it by setting the value to `true`. It is equivalent to specify `-X` in maven command.