### PR TITLE
BDSGOLD-301. Primarily copying README.md to address test_pyspark_shel…

### DIFF
--- a/scripts/justinstall.sh
+++ b/scripts/justinstall.sh
@@ -139,6 +139,11 @@ cp -rp $spark_git_dir/sql/hive/target/*.jar ./sql/hive/target/
 cp -rp $spark_git_dir/sql/hive-thriftserver/target/*.jar ./sql/hive-thriftserver/target/
 cp -rp $spark_git_dir/data/* ./data/
 cp -rp $spark_git_dir/R/lib/* ./R/lib/
+cp -rp $spark_git_dir/licenses/* ./licenses/
+cp -p $spark_git_dir/README.md ./
+cp -p $spark_git_dir/LICENSE ./
+cp -p $spark_git_dir/NOTICE ./
+cp -p $spark_git_dir/CONTRIBUTING.md ./
 popd
 
 pushd ${RPM_DIR}


### PR DESCRIPTION
…l.sh test breakage. Also copying LICENSE, NOTICE, CONTRIBUTING.md and populating licenses folder.

The `test_pyspark_shell.sh` places README.md from spark home directory [or /opt/alti-spark-x.x.x/] into hdfs directory which is used by `pyspark_shell_examples.py` to create TF vectors. README.md file was missing under `/opt/alti-spark-2.3.2/` directory as it was not copied as a part of spark core rpm.